### PR TITLE
Incorporate successor data structures and remove stash submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "libs/rmq"]
 	path = extlib/rmq
 	url = https://github.com/hferrada/rmq
-[submodule "libs/stash"]
-	path = extlib/stash
-	url = https://github.com/pdinklag/stash/
 [submodule "libs/malloc_count"]
 	path = extlib/malloc_count
 	url = https://github.com/bingmann/malloc_count

--- a/lce-test/lce_semi_synchronizing_sets.hpp
+++ b/lce-test/lce_semi_synchronizing_sets.hpp
@@ -14,7 +14,7 @@
 #include "util/synchronizing_sets/ring_buffer.hpp"
 #include "util/synchronizing_sets/lce-rmq.hpp"
 #include "util/util.hpp"
-#include <stash/pred/index.hpp>
+#include "util/successor/index.hpp"
 
 #include <tlx/define/likely.hpp>
 
@@ -256,11 +256,11 @@ private:
       fp *= 256;
       fp += (unsigned char) text_[kTau+fingerprints.size() - 1];
       fp %= kPrime;
-				
+                
       unsigned __int128 first_char_influence = text_[fingerprints.size() - 1];
       first_char_influence *= TwoPowTauModQ;
       first_char_influence %= kPrime;
-				
+                
       if(first_char_influence < fp) {
         fp -= first_char_influence;
       } else {

--- a/lce-test/util/successor/binsearch.hpp
+++ b/lce-test/util/successor/binsearch.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "helpers/util.hpp"
+#include "result.hpp"
+
+namespace stash {
+namespace pred {
+
+// the "bs" data structure for successor queries
+template<typename array_t, typename item_t>
+class binsearch {
+private:
+    const array_t* m_array;
+    size_t m_num;
+    item_t m_min;
+    item_t m_max;
+
+public:
+    inline binsearch() : m_array(nullptr), m_num(0), m_min(), m_max() {
+    }
+
+    inline binsearch(binsearch&& other) {
+        *this = other;
+    }
+
+    inline binsearch(const binsearch& other) {
+        *this = other;
+    }
+
+    inline binsearch(const array_t& array)
+        : m_num(array.size()),
+          m_min(array[0]),
+          m_max(array[m_num-1]),
+          m_array(&array) {
+
+        assert_sorted_ascending(array);
+    }
+
+    inline binsearch& operator=(binsearch&& other) {
+        m_array = other.m_array;
+        m_num = other.m_num;
+        m_min = other.m_min;
+        m_max = other.m_max;
+        return *this;
+    }
+
+    inline binsearch& operator=(const binsearch& other) {
+        m_array = other.m_array;
+        m_num = other.m_num;
+        m_min = other.m_min;
+        m_max = other.m_max;
+        return *this;
+    }
+
+    // finds the greatest element less than OR equal to x
+    inline result predecessor(const item_t x) const {
+        if(unlikely(x < m_min))  return result { false, 0 };
+        if(unlikely(x >= m_max)) return result { true, m_num-1 };
+
+        size_t p = 0;
+        size_t q = m_num - 1;
+
+        while(p < q - 1) {
+            assert(x >= (*m_array)[p]);
+            assert(x < (*m_array)[q]);
+
+            const size_t m = (p + q) >> 1ULL;
+
+            const bool le = ((*m_array)[m] <= x);
+
+            /*
+                the following is a fast form of:
+                if(le) p = m; else q = m;
+            */
+            const size_t le_mask = -size_t(le);
+            const size_t gt_mask = ~le_mask;
+
+            if(le) assert(le_mask == SIZE_MAX && gt_mask == 0ULL);
+            else   assert(gt_mask == SIZE_MAX && le_mask == 0ULL);
+
+            p = (le_mask & m) | (gt_mask & p);
+            q = (gt_mask & m) | (le_mask & q);
+        }
+
+        return result { true, p };
+    }
+
+    // finds the smallest element greater than OR equal to x
+    inline result successor(const item_t x) const {
+        if(unlikely(x <= m_min)) return result { true, 0 };
+        if(unlikely(x > m_max))  return result { false, 0 };
+
+        size_t p = 0;
+        size_t q = m_num - 1;
+
+        while(p < q - 1) {
+            assert(x > (*m_array)[p]);
+            assert(x <= (*m_array)[q]);
+
+            const size_t m = (p + q) >> 1ULL;
+
+            const bool lt = ((*m_array)[m] < x);
+
+            /*
+                the following is a fast form of:
+                if(lt) p = m; else q = m;
+            */
+            const size_t lt_mask = -size_t(lt);
+            const size_t ge_mask = ~lt_mask;
+
+            p = (lt_mask & m) | (ge_mask & p);
+            q = (ge_mask & m) | (lt_mask & q);
+        }
+
+        return result { true, q };
+    }
+};
+
+}}

--- a/lce-test/util/successor/binsearch_cache.hpp
+++ b/lce-test/util/successor/binsearch_cache.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "helpers/util.hpp"
+#include "result.hpp"
+
+namespace stash {
+namespace pred {
+
+// the "bs*" data structure for successor queries
+template<typename array_t, typename item_t, size_t m_cache_num = 512ULL / sizeof(item_t)>
+class binsearch_cache {
+private:
+    const array_t* m_array;
+    size_t m_num;
+    item_t m_min;
+    item_t m_max;
+
+public:
+    inline binsearch_cache() : m_array(nullptr), m_num(0), m_min(), m_max() {
+    }
+
+    inline binsearch_cache(binsearch_cache&& other) {
+        *this = other;
+    }
+
+    inline binsearch_cache(const binsearch_cache& other) {
+        *this = other;
+    }
+
+    inline binsearch_cache(const array_t& array)
+        : m_num(array.size()),
+          m_min(array[0]),
+          m_max(array[m_num-1]),
+          m_array(&array) {
+
+        assert_sorted_ascending(array);
+    }
+
+    inline binsearch_cache& operator=(binsearch_cache&& other) {
+        m_array = other.m_array;
+        m_num = other.m_num;
+        m_min = other.m_min;
+        m_max = other.m_max;
+        return *this;
+    }
+
+    inline binsearch_cache& operator=(const binsearch_cache& other) {
+        m_array = other.m_array;
+        m_num = other.m_num;
+        m_min = other.m_min;
+        m_max = other.m_max;
+        return *this;
+    }
+
+    // finds the smallest element greater than OR equal to x
+    // seeded using a start interval
+    inline result predecessor_seeded(const item_t x, size_t p, size_t q) const {
+        assert(x >= m_min && x < m_max);
+        while(q - p > m_cache_num) {
+            assert(x >= (*m_array)[p]);
+
+            const size_t m = (p + q) >> 1ULL;
+
+            const bool le = ((*m_array)[m] <= x);
+
+            /*
+                the following is a fast form of:
+                if(le) p = m; else q = m;
+            */
+            const size_t le_mask = -size_t(le);
+            const size_t gt_mask = ~le_mask;
+
+            p = (le_mask & m) | (gt_mask & p);
+            q = (gt_mask & m) | (le_mask & q);
+        }
+
+        // linear search
+        while((*m_array)[p] <= x) ++p;
+        assert((*m_array)[p-1] <= x);
+
+        return result { true, p-1 };
+    }
+
+    // finds the greatest element less than OR equal to x
+    inline result predecessor(const item_t x) const {
+        if(unlikely(x < m_min))  return result { false, 0 };
+        if(unlikely(x >= m_max)) return result { true, m_num-1 };
+        return predecessor_seeded(x, 0, m_num - 1);
+    }
+
+    // finds the smallest element greater than OR equal to x
+    // seeded using a start interval
+    inline result successor_seeded(const item_t x, size_t p, size_t q) const {
+        assert(x >= m_min && x < m_max);
+        while(q - p > m_cache_num) {
+            assert(x > (*m_array)[p]);
+            assert(x <= (*m_array)[q]);
+
+            const size_t m = (p + q) >> 1ULL;
+
+            const bool lt = ((*m_array)[m] < x);
+
+
+            /*
+                the following is a fast form of:
+                if(lt) p = m; else q = m;
+            */
+            const size_t lt_mask = -size_t(lt);
+            const size_t ge_mask = ~lt_mask;
+
+            p = (lt_mask & m) | (ge_mask & p);
+            q = (ge_mask & m) | (lt_mask & q);
+        }
+
+        // linear search
+        while((*m_array)[p] < x) ++p;
+        assert((*m_array)[p] >= x);
+
+        return result { true, p };
+    }
+
+    // finds the smallest element greater than OR equal to x
+    inline result successor(const item_t x) const {
+        if(unlikely(x <= m_min)) return result { true, 0 };
+        if(unlikely(x > m_max))  return result { false, 0 };
+        return successor_seeded(x, 0, m_num - 1);
+    }
+};
+
+}}

--- a/lce-test/util/successor/helpers/bit_rank.hpp
+++ b/lce-test/util/successor/helpers/bit_rank.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <utility>
+
+#include "util.hpp"
+#include "bit_vector.hpp"
+#include "int_vector.hpp"
+
+namespace stash {
+
+class bit_rank {
+private:
+    static constexpr size_t SUP_SZ = 4096;
+    static constexpr size_t SUP_MSK = 4095;
+    static constexpr size_t SUP_W = 12;
+
+    static constexpr size_t BLOCKS_PER_SB = SUP_SZ >> 6ULL;
+    static constexpr size_t SB_INNER_RS = SUP_W - 6ULL;
+        
+    const bit_vector* m_bv;
+
+    int_vector m_blocks;    // size 64 each
+    int_vector m_supblocks; // size SUP_SZ each
+
+public:
+    inline bit_rank(const bit_vector& bv) : m_bv(&bv) {
+        const size_t n = m_bv->size();
+
+        // determine number of superblocks and superblock entry width
+        const size_t sw = log2_ceil(n-1);
+        const size_t sq = n >> SUP_W;
+        const size_t sm = n & SUP_MSK;
+        m_supblocks.resize(sm ? sq + 1 : sq, sw);
+
+        // determine number of blocks and block width
+        const size_t bq = n >> 6ULL; // div 64
+        const size_t bm = n & 63ULL; // mod 64
+        m_blocks.resize(bm ? bq + 1 : bq, SUP_W);
+
+        // construct
+        {
+            size_t rank_bv = 0; // 1-bits in whole BV
+            size_t rank_sb = 0; // 1-bits in current superblock
+            size_t cur_sb = 0;  // current superblock
+
+            for(size_t j = 0; j < m_blocks.size(); j++) {
+                size_t i = j >> SB_INNER_RS;
+                if(i > cur_sb) {
+                    // we reached a new superblock
+                    m_supblocks[cur_sb] = rank_bv;
+                    rank_sb = 0;
+                    cur_sb = i;
+                }
+
+                auto rank_b = rank1_u64(m_bv->block64(j));
+                rank_sb += rank_b;
+                rank_bv += rank_b;
+
+                m_blocks[j] = rank_sb;
+            }
+        }
+    }
+
+    inline bit_rank() : m_bv(nullptr) {
+    }
+
+    inline bit_rank(const bit_rank& other) {
+        *this = other;
+    }
+
+    inline bit_rank(bit_rank&& other) {
+        *this = std::move(other);
+    }
+
+    inline bit_rank& operator=(const bit_rank& other) {
+        m_bv = other.m_bv;
+        m_blocks = other.m_blocks;
+        m_supblocks = other.m_supblocks;
+        return *this;
+    }
+
+    inline bit_rank& operator=(bit_rank&& other) {
+        m_bv = other.m_bv;
+        m_blocks = std::move(other.m_blocks);
+        m_supblocks = std::move(other.m_supblocks);
+        return *this;
+    }
+
+    inline void reassign(bit_rank&& other, const bit_vector& bv) {
+        // FIXME: this shouldn't be necessary
+        *this = std::move(other),
+        m_bv = &bv;
+    }
+
+    inline size_t rank1(const size_t x) const {
+        size_t r = 0;
+        const size_t i = x >> SUP_W;
+        if(i > 0) r += m_supblocks[i - 1];
+        const size_t j = x >> 6ULL;
+
+        const size_t k = j - i * BLOCKS_PER_SB;
+        if(k > 0) r += m_blocks[j - 1];
+
+        r += rank1_u64(m_bv->block64(j), x & 63ULL);
+        return r;
+    }
+
+    inline size_t operator()(size_t i) const {
+        return rank1(i);
+    }
+
+    inline size_t rank0(size_t x) const {
+        return x + 1 - rank1(x);
+    }
+};
+
+}

--- a/lce-test/util/successor/helpers/bit_select.hpp
+++ b/lce-test/util/successor/helpers/bit_select.hpp
@@ -1,0 +1,283 @@
+#pragma once
+
+#include <utility>
+
+#include "util.hpp"
+#include "bit_vector.hpp"
+#include "int_vector.hpp"
+
+namespace stash {
+
+template<bool m_bit>
+class bit_select {
+private:
+    static constexpr uint8_t basic_rank(uint64_t v);
+    static constexpr uint8_t basic_rank(uint64_t v, uint8_t x);
+    static constexpr uint8_t basic_rank(uint64_t v, uint8_t a, uint8_t b);
+    static constexpr uint8_t basic_select(uint64_t v, uint8_t k);
+    static constexpr uint8_t basic_select(uint64_t v, uint8_t l, uint8_t k);
+
+    const bit_vector* m_bv;
+
+    size_t m_max;
+    size_t m_block_size;
+    size_t m_supblock_size;
+    size_t m_blocks_per_supblock;
+
+    int_vector m_blocks;
+    int_vector m_supblocks;
+
+public:
+    inline bit_select(const bit_vector& bv) {
+        m_bv = &bv;
+
+        const size_t n = bv.size();
+        const size_t log_n = log2_ceil(n - 1);
+
+        // construct
+        m_block_size    = log_n;
+        m_supblock_size = log_n * log_n;
+        m_blocks_per_supblock = log_n;
+
+        m_supblocks = int_vector(idiv_ceil(n, m_supblock_size), log_n);
+        m_blocks = int_vector(idiv_ceil(n, m_block_size), log_n);
+
+        m_max = 0;
+        size_t r_sb = 0; // current bit count in superblock
+        size_t r_b = 0;  // current bit count in block
+
+        size_t cur_sb = 0;        // current superblock
+        size_t cur_sb_offset = 0; // starting position of current superblock
+        size_t longest_sb = 0;    // length of longest superblock
+
+        size_t cur_b = 0; // current block
+
+        const size_t num_blocks = bv.num_blocks();
+        
+        for(size_t i = 0; i < num_blocks; i++) {
+            const auto v = bv.block64(i);
+            
+            uint8_t r;
+            if(i + 1 < num_blocks) {
+                // get amount flag bits in whole data element
+                r = basic_rank(v);
+            } else {
+                // only get amount of flag bits up to end of bit vector
+                const size_t m = n & 63ULL; // mod 64
+                if(m > 0) {
+                    r = basic_rank(v, m-1);
+                } else {
+                    r = basic_rank(v); // full element, but last one
+                }
+            }
+
+            m_max += r;
+
+            if(r_b + r >= m_block_size) {
+                // entered new block
+
+                // amount of bits needed to fill current block
+                size_t distance_b = m_block_size - r_b;
+
+                // stores the offset of the last bit in the current block
+                uint8_t offs = 0;
+
+                r_b += r;
+
+                size_t distance_sum = 0;
+                while(r_b >= m_block_size) {
+                    // find exact position of the bit in question
+                    offs = basic_select(v, offs, distance_b);
+                    assert(SELECT_FAIL != offs);
+
+                    const size_t pos = (i << 6ULL) + offs; // mul 64
+
+                    distance_sum += distance_b;
+                    r_sb += distance_b;
+                    if(r_sb >= m_supblock_size) {
+                        // entered new superblock
+                        longest_sb = std::max(longest_sb, pos - cur_sb_offset);
+                        cur_sb_offset = pos;
+
+                        m_supblocks[cur_sb++] = pos;
+
+                        r_sb -= m_supblock_size;
+                    }
+
+                    m_blocks[cur_b++] = pos - cur_sb_offset;
+                    r_b -= m_block_size;
+                    distance_b = m_block_size;
+
+                    ++offs;
+                }
+
+                assert(size_t(r) >= distance_sum);
+                r_sb += r - distance_sum;
+            } else {
+                r_b  += r;
+                r_sb += r;
+            }
+        }
+
+        longest_sb = std::max(longest_sb, n - cur_sb_offset);
+        const size_t w_block = log2_ceil(longest_sb);
+
+        m_supblocks.rebuild(cur_sb, log_n);
+        m_blocks.rebuild(cur_b, w_block);
+    }
+
+    inline bit_select()
+        : m_bv(nullptr),
+          m_max(0),
+          m_block_size(0),
+          m_supblock_size(0),
+          m_blocks_per_supblock(0) {
+    }
+
+    inline bit_select(const bit_select& other) {
+        *this = other;
+    }
+
+    inline bit_select(bit_select&& other) {
+        *this = std::move(other);
+    }
+
+    inline bit_select& operator=(const bit_select& other) {
+        m_bv = other.m_bv;
+        m_max = other.m_max;
+        m_block_size = other.m_block_size;
+        m_supblock_size = other.m_supblock_size;
+        m_blocks_per_supblock = other.m_blocks_per_supblock;
+        m_blocks = other.m_blocks;
+        m_supblocks = other.m_supblocks;
+        return *this;
+    }
+
+    inline bit_select& operator=(bit_select&& other) {
+        m_bv = other.m_bv;
+        m_max = other.m_max;
+        m_block_size = other.m_block_size;
+        m_supblock_size = other.m_supblock_size;
+        m_blocks_per_supblock = other.m_blocks_per_supblock;
+        m_blocks = std::move(other.m_blocks);
+        m_supblocks = std::move(other.m_supblocks);
+        return *this;
+    }
+
+    inline void reassign(bit_select&& other, const bit_vector& bv) {
+        // FIXME: this shouldn't be necessary
+        *this = std::move(other),
+        m_bv = &bv;
+    }
+
+    inline size_t select(size_t x) const {
+        assert(x > 0);
+        if(x > m_max) return m_bv->size();
+
+        size_t pos = 0;
+
+        //narrow down to block
+        {
+            const size_t i = x / m_supblock_size;
+            const size_t j = x / m_block_size;
+
+            if(i > 0) {
+                pos += m_supblocks[i-1];
+                x -= i * m_supblock_size;
+            }
+            if(x == 0) return pos;
+
+            // block j is the k-th block within the i-th superblock
+            size_t k = j - i * m_blocks_per_supblock;
+            if(k > 0) {
+                pos += m_blocks[j-1];
+                x   -= k * m_block_size;
+            }
+            if(x == 0) return pos;
+
+            if(i > 0 || k > 0) ++pos; // offset from block boundary
+        }
+
+        // from this point forward, search directly in the bit vector
+        size_t i = pos >> 6ULL; // div 64
+        size_t offs  = pos & 63ULL; // mod 64
+
+        uint64_t block = m_bv->block64(i);
+        uint8_t s = basic_select(block, offs, x);
+        if(s != SELECT_FAIL) {
+            // found in first data segment
+            return pos + s - offs;
+        } else {
+            // linearly search in the next segments
+            x -= basic_rank(block, offs, 63ULL);
+            while(s == SELECT_FAIL) {
+                ++i;
+                pos = i << 6ULL; // mul 64
+                block = m_bv->block64(i);
+                s = basic_select(block, x);
+                if(s == SELECT_FAIL) x -= basic_rank(block);
+            };
+
+            return pos + s;
+        }
+    }
+
+    inline size_t operator()(size_t x) const {
+        return select(x);
+    }
+};
+
+template<>
+inline constexpr uint8_t bit_select<0>::basic_rank(uint64_t v) {
+    return 64ULL - rank1_u64(v);
+}
+
+template<>
+inline constexpr uint8_t bit_select<0>::basic_rank(uint64_t v, uint8_t x) {
+    return x + 1 - rank1_u64(v, x);
+}
+
+template<>
+inline constexpr uint8_t bit_select<0>::basic_rank(uint64_t v, uint8_t a, uint8_t b) {
+    return (b-a+1) - rank1_u64(v, a, b);
+}
+
+template<>
+inline constexpr uint8_t bit_select<0>::basic_select(uint64_t v, uint8_t k) {
+    return select0_u64(v, k);
+}
+
+template<>
+inline constexpr uint8_t bit_select<0>::basic_select(uint64_t v, uint8_t l, uint8_t k) {
+    return select0_u64(v, l, k);
+}
+
+template<>
+inline constexpr uint8_t bit_select<1>::basic_rank(uint64_t v) {
+    return rank1_u64(v);
+}
+
+template<>
+inline constexpr uint8_t bit_select<1>::basic_rank(uint64_t v, uint8_t x) {
+    return rank1_u64(v, x);
+}
+
+template<>
+inline constexpr uint8_t bit_select<1>::basic_rank(uint64_t v, uint8_t a, uint8_t b) {
+    return rank1_u64(v, a, b);
+}
+
+template<>
+inline constexpr uint8_t bit_select<1>::basic_select(uint64_t v, uint8_t k) {
+    return select1_u64(v, k);
+}
+
+template<>
+inline constexpr uint8_t bit_select<1>::basic_select(uint64_t v, uint8_t l, uint8_t k) {
+    return select1_u64(v, l, k);
+}
+
+using bit_select0 = bit_select<0>;
+using bit_select1 = bit_select<1>;
+
+}

--- a/lce-test/util/successor/helpers/bit_vector.hpp
+++ b/lce-test/util/successor/helpers/bit_vector.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <utility>
+
+#include "util.hpp"
+
+namespace stash {
+
+class bit_vector {
+private:
+    size_t m_size;
+    std::vector<uint64_t> m_bits;
+    
+    inline static size_t block(size_t i) {
+        return i >> 6ULL; // divide by 64
+    }
+
+    inline static size_t offset(size_t i) {
+        return i & 63ULL; // mod 64
+    }
+
+    inline bool bitread(size_t i) const {
+        const size_t q = block(i);
+        const size_t k = offset(i);
+        const size_t mask = (1ULL << k);
+        return bool(m_bits[q] & mask);
+    }
+
+    inline void bitset(size_t i, bool b) {
+        const size_t q = block(i);
+        const size_t k = offset(i);
+        const size_t mask = (1ULL << k);
+
+        // TODO: avoid branch!
+        if(b) {
+            m_bits[q] |= mask;
+        } else {
+            m_bits[q] &= ~mask;
+        }
+    }
+
+public:
+    struct Ref {
+        bit_vector* bv;
+        size_t i;
+        
+        inline operator bool() const {
+            return bv->bitread(i);
+        }
+
+        inline void operator=(bool b) {
+            bv->bitset(i, b);
+        }
+    };
+
+    inline bit_vector() : m_size(0) {
+    }
+
+    inline bit_vector(const bit_vector& other) {
+        *this = other;
+    }
+
+    inline bit_vector(bit_vector&& other) {
+        *this = std::move(other);
+    }
+
+    inline bit_vector(size_t size) : m_size(size) {
+        m_bits.resize(idiv_ceil(size, 64ULL));
+    }
+
+    inline bit_vector(const std::vector<bool>& bv) : bit_vector(bv.size()) {
+        // FIXME: is there no faster way?
+        for(size_t i = 0; i < m_size; i++) {
+            bitset(i, bv[i]);
+        }
+    }
+
+    inline bit_vector& operator=(const bit_vector& other) {
+        m_size = other.m_size;
+        m_bits = other.m_bits;
+        return *this;
+    }
+
+    inline bit_vector& operator=(bit_vector&& other) {
+        m_size = std::move(other.m_size);
+        m_bits = std::move(other.m_bits);
+        return *this;
+    }
+
+    inline uint64_t block64(size_t i) const {
+        return m_bits[i];
+    }
+
+    inline size_t num_blocks() const {
+        return m_bits.size();
+    }
+
+    inline bool operator[](size_t i) const {
+        return bitread(i);
+    }
+
+    inline Ref operator[](size_t i) {
+        return Ref { this, i };
+    }
+
+    inline size_t size() const {
+        return m_size;
+    }
+};
+
+}

--- a/lce-test/util/successor/helpers/int_vector.hpp
+++ b/lce-test/util/successor/helpers/int_vector.hpp
@@ -1,0 +1,158 @@
+#pragma once
+    
+#include <vector>
+#include <utility>
+
+#include "util.hpp"
+
+namespace stash {
+
+class int_vector {
+private:
+    size_t m_size;
+    size_t m_width;
+    size_t m_mask;
+    std::vector<uint64_t> m_data;
+
+    inline void set(size_t i, uint64_t v) {
+        v &= m_mask; // make sure it fits...
+        
+        const size_t j = i * m_width;
+        const size_t a = j >> 6ULL;       // left border
+        const size_t b = (j + m_width - 1ULL) >> 6ULL; // right border
+        if(a < b) {
+            // the bits are the suffix of m_data[a] and prefix of m_data[b]
+            const size_t da = j & 63ULL;
+            const size_t wa = 64ULL - da;
+            const size_t wb = m_width - wa;
+            const size_t db = 64ULL - wb;
+
+            // combine the da lowest bits from a and the wa lowest bits of v
+            const uint64_t a_lo = m_data[a] & bit_mask(da);
+            const uint64_t v_lo = v & bit_mask(wa);
+            m_data[a] = (v_lo << da) | a_lo;
+
+            // combine the db highest bits of b and the wb highest bits of v
+            const uint64_t b_hi = m_data[b] >> wb;
+            const uint64_t v_hi = v >> wa;
+            m_data[b] = (b_hi << wb) | v_hi;
+        } else {
+            const size_t dl = j & 63ULL;
+            const size_t dvl = dl + m_width;
+            
+            const uint64_t xa = m_data[a];
+            const uint64_t lo = xa & bit_mask(dl);
+            const uint64_t hi = xa >> dvl;
+            m_data[a] = lo | (v << dl) | (hi << dvl);
+        }
+    }
+
+    inline uint64_t get(size_t i) const {
+        const size_t j = i * m_width;
+        const size_t a = j >> 6ULL;                    // left border
+        const size_t b = (j + m_width - 1ULL) >> 6ULL; // right border
+
+        // da is the distance of a's relevant bits from the left border
+        const size_t da = j & 63ULL;
+
+        // wa is the number of a's relevant bits
+        const size_t wa = 64ULL - da;
+
+        // get the wa highest bits from a
+        const uint64_t a_hi = m_data[a] >> da;
+
+        // get b (its high bits will be masked away below)
+        // NOTE: we could save this step if we knew a == b,
+        //       but the branch caused by checking that is too expensive
+        const uint64_t b_lo = m_data[b];
+
+        // combine
+        return ((b_lo << wa) | a_hi) & m_mask;
+    }
+
+public:
+    struct Ref {
+        int_vector* iv;
+        size_t i;
+
+        inline operator uint64_t() const {
+            return iv->get(i);
+        }
+
+        inline void operator=(uint64_t v) {
+            iv->set(i, v);
+        }
+    };
+
+    inline int_vector() : m_size(0), m_width(0), m_mask(0) {
+    }
+
+    inline int_vector(const int_vector& other) {
+        *this = other;
+    }
+
+    inline int_vector(int_vector&& other) {
+        *this = std::move(other);
+    }
+
+    inline int_vector(size_t size, size_t width) {
+        resize(size, width);
+    }
+
+    inline int_vector& operator=(const int_vector& other) {
+        m_size = other.m_size;
+        m_width = other.m_width;
+        m_mask = other.m_mask;
+        m_data = other.m_data;
+        return *this;
+    }
+
+    inline int_vector& operator=(int_vector&& other) {
+        m_size = other.m_size;
+        m_width = other.m_width;
+        m_mask = other.m_mask;
+        m_data = std::move(other.m_data);
+        return *this;
+    }
+
+    inline void resize(size_t size, size_t width) {
+        m_size = size;
+        m_width = width;
+        m_mask = bit_mask(width);
+        
+        const size_t bits = m_size * m_width;
+        const size_t q = bits >> 6ULL; // divide by 64
+        const size_t k = bits & 63ULL; // mod 64
+        m_data.resize(k ? q + 1 : q);
+    }
+
+    inline void rebuild(size_t size, size_t width) {
+        int_vector new_iv(size, width);
+        for(size_t i = 0; i < size; i++) {
+            new_iv.set(i, get(i));
+        }
+        
+        m_size = new_iv.m_size;
+        m_width = new_iv.m_width;
+        m_mask = new_iv.m_mask;
+        m_data = std::move(new_iv.m_data);
+    }
+
+    inline void rebuild(size_t size) {
+        rebuild(size, m_width);
+    }
+
+    inline uint64_t operator[](size_t i) const {
+        return get(i);
+    }
+
+    inline Ref operator[](size_t i) {
+        return Ref { this, i };
+    }
+
+    inline size_t size() const {
+        return m_size;
+    }
+};
+
+}

--- a/lce-test/util/successor/helpers/rank_select_util.hpp
+++ b/lce-test/util/successor/helpers/rank_select_util.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstdint>
+
+namespace stash {
+
+// creates a mask consisting of the given number of bits
+inline constexpr uint64_t bit_mask(uint64_t bits) {
+    return (1ULL << bits) - 1ULL;
+}
+
+// rank on a 64-bit value
+inline constexpr uint8_t rank1_u64(uint64_t v) {
+    return __builtin_popcountll(v);
+}
+
+// rank on a 64-bit value up to bit x
+inline constexpr uint8_t rank1_u64(uint64_t v, uint8_t x) {
+    return __builtin_popcountll(v & (UINT64_MAX >> (~x & 63ULL))); // 63 - x
+}
+
+// rank on a 64-bit value between a and b
+inline constexpr uint8_t rank1_u64(uint64_t v, uint8_t a, uint8_t b) {
+    const uint64_t mask_a = UINT64_MAX << a;
+    const uint64_t mask_b = UINT64_MAX >> (~b & 63ULL); // 63 - b
+    return __builtin_popcountll(v & mask_a & mask_b);
+}
+
+/// \brief Returned by \ref select0 and \ref select1 in case the searched
+///        bit does not exist in the given input value.
+constexpr uint8_t SELECT_FAIL = 0xFF;
+
+/// \brief Finds the position of the k-th 1-bit in the binary representation
+///        of the given value.
+///
+/// The search starts with the least significant bit.
+///
+/// \param v the input value
+/// \param k the searched 1-bit
+/// \return the position of the k-th 1-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select1_u64(uint64_t v, uint8_t k) {
+    uint8_t pos = 0;
+    while(v && k && pos < 64) {
+        const size_t z = __builtin_ctzll(v)+1;
+        pos += z;
+        v >>= z;
+        --k;
+    }
+    return k ? SELECT_FAIL : pos - 1;
+}
+
+/// \brief Finds the position of the k-th 1-bit in the binary representation
+///        of the given value.
+///
+/// \param v the input value
+/// \param l the bit (LSBF order) to start searching from
+/// \param k the searched 1-bit
+/// \return the position of the k-th 1-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select1_u64(uint64_t v, uint8_t l, uint8_t k) {
+    const uint8_t pos = select1_u64(v >> l, k);
+    return (pos != SELECT_FAIL) ? (l + pos) : SELECT_FAIL;
+}
+
+/// \brief Finds the position of the k-th 0-bit in the binary representation
+///        of the given value.
+///
+/// The search starts with the least significant bit.
+///
+/// \param v the input value
+/// \param k the searched 0-bit
+/// \return the position of the k-th 0-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select0_u64(uint64_t v, uint8_t k) {
+    return select1_u64(~v, k);
+}
+
+/// \brief Finds the position of the k-th 0-bit in the binary representation
+///        of the given value.
+///
+/// \param v the input value
+/// \param l the bit (LSBF order) to start searching from
+/// \param k the searched 0-bit
+/// \return the position of the k-th 0-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select0_u64(uint64_t v, uint8_t l, uint8_t k) {
+    return select1_u64(~v, l, k);
+}
+
+}

--- a/lce-test/util/successor/helpers/util.hpp
+++ b/lce-test/util/successor/helpers/util.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cassert>
+
+namespace stash {
+
+template<typename array_t>
+void assert_sorted_ascending(const array_t& a) {
+    #ifndef NDEBUG
+    const size_t num = a.size();
+    if(num > 1) {                
+        auto prev = a[0];
+        for(size_t i = 1; i < num; i++) {
+            auto next = a[i];
+            assert(prev <= next);
+            prev = next;
+        }
+    }
+    #endif
+}
+
+inline constexpr uint64_t log2_ceil(uint64_t x) {
+    return 64ULL - __builtin_clzll(x);
+}
+
+// creates a mask consisting of the given number of bits
+inline constexpr uint64_t bit_mask(uint64_t bits) {
+    return (1ULL << bits) - 1ULL;
+}
+
+// rank on a 64-bit value
+inline constexpr uint8_t rank1_u64(uint64_t v) {
+    return __builtin_popcountll(v);
+}
+
+// rank on a 64-bit value up to bit x
+inline constexpr uint8_t rank1_u64(uint64_t v, uint8_t x) {
+    return __builtin_popcountll(v & (UINT64_MAX >> (~x & 63ULL))); // 63 - x
+}
+
+// rank on a 64-bit value between a and b
+inline constexpr uint8_t rank1_u64(uint64_t v, uint8_t a, uint8_t b) {
+    const uint64_t mask_a = UINT64_MAX << a;
+    const uint64_t mask_b = UINT64_MAX >> (~b & 63ULL); // 63 - b
+    return __builtin_popcountll(v & mask_a & mask_b);
+}
+
+/// \brief Returned by \ref select0 and \ref select1 in case the searched
+///        bit does not exist in the given input value.
+constexpr uint8_t SELECT_FAIL = 0xFF;
+
+/// \brief Finds the position of the k-th 1-bit in the binary representation
+///        of the given value.
+///
+/// The search starts with the least significant bit.
+///
+/// \param v the input value
+/// \param k the searched 1-bit
+/// \return the position of the k-th 1-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select1_u64(uint64_t v, uint8_t k) {
+    uint8_t pos = 0;
+    while(v && k && pos < 64) {
+        const size_t z = __builtin_ctzll(v)+1;
+        pos += z;
+        v >>= z;
+        --k;
+    }
+    return k ? SELECT_FAIL : pos - 1;
+}
+
+/// \brief Finds the position of the k-th 1-bit in the binary representation
+///        of the given value.
+///
+/// \param v the input value
+/// \param l the bit (LSBF order) to start searching from
+/// \param k the searched 1-bit
+/// \return the position of the k-th 1-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select1_u64(uint64_t v, uint8_t l, uint8_t k) {
+    const uint8_t pos = select1_u64(v >> l, k);
+    return (pos != SELECT_FAIL) ? (l + pos) : SELECT_FAIL;
+}
+
+/// \brief Finds the position of the k-th 0-bit in the binary representation
+///        of the given value.
+///
+/// The search starts with the least significant bit.
+///
+/// \param v the input value
+/// \param k the searched 0-bit
+/// \return the position of the k-th 0-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select0_u64(uint64_t v, uint8_t k) {
+    return select1_u64(~v, k);
+}
+
+/// \brief Finds the position of the k-th 0-bit in the binary representation
+///        of the given value.
+///
+/// \param v the input value
+/// \param l the bit (LSBF order) to start searching from
+/// \param k the searched 0-bit
+/// \return the position of the k-th 0-bit (LSBF and zero-based),
+///         or \ref SELECT_FAIL if no such bit exists
+inline constexpr uint8_t select0_u64(uint64_t v, uint8_t l, uint8_t k) {
+    return select1_u64(~v, l, k);
+}
+
+}
+
+#define likely(x)   __builtin_expect(x, 1)
+#define unlikely(x) __builtin_expect(x, 0)

--- a/lce-test/util/successor/index.hpp
+++ b/lce-test/util/successor/index.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <algorithm>
+
+#include "helpers/util.hpp"
+#include "helpers/int_vector.hpp"
+
+#include "result.hpp"
+#include "binsearch_cache.hpp"
+
+namespace stash {
+namespace pred {
+
+// the "idx" data structure for successor queries
+template<
+    typename array_t,
+    typename item_t,
+    size_t m_lo_bits,
+    size_t m_cache_num = 512ULL / sizeof(item_t)>
+class index {
+private:
+    static constexpr size_t m_hi_bits = 8 * sizeof(item_t) - m_lo_bits;
+
+    static constexpr uint64_t hi(uint64_t x) {
+        return x >> m_lo_bits;
+    }
+
+    const array_t* m_array;
+    size_t m_num;
+    item_t m_min;
+    item_t m_max;
+
+    uint64_t m_key_min;
+    uint64_t m_key_max;
+
+    int_vector m_hi_idx;
+
+    using lo_pred_t = binsearch_cache<array_t, item_t, m_cache_num>;
+    lo_pred_t m_lo_pred;
+
+public:
+    inline index(const array_t& array)
+        : m_num(array.size()),
+          m_min(array[0]),
+          m_max(array[m_num-1]),
+          m_array(&array) {
+
+        assert_sorted_ascending(array);
+
+        // build an index for high bits
+        m_key_min = uint64_t(m_min) >> m_lo_bits;
+        m_key_max = uint64_t(m_max) >> m_lo_bits;
+
+        m_hi_idx = int_vector(m_key_max - m_key_min + 2, log2_ceil(m_num-1));
+        m_hi_idx[0] = 0;
+        uint64_t prev_key = m_key_min;
+        for(size_t i = 1; i < m_num; i++) {
+            const uint64_t cur_key = hi(array[i]);
+            if(cur_key > prev_key) {
+                for(uint64_t key = prev_key + 1; key <= cur_key; key++) {
+                    m_hi_idx[key - m_key_min] = i - 1;
+                }
+            }
+            prev_key = cur_key;
+        }
+
+        assert(prev_key == m_key_max);
+        m_hi_idx[m_key_max - m_key_min] = m_num - 1;
+
+        // build the predecessor data structure for low bits
+        m_lo_pred = lo_pred_t(array);
+    }
+
+    // finds the greatest element less than OR equal to x
+    inline result predecessor(const item_t x) const {
+        if(unlikely(x < m_min))  return result { false, 0 };
+        if(unlikely(x >= m_max)) return result { true, m_num-1 };
+
+        const uint64_t key = hi(x) - m_key_min;
+        const size_t q = m_hi_idx[key+1];
+
+        if(unlikely(x == (*m_array)[q])) {
+            return result { true, q };
+        } else {
+            const size_t p = m_hi_idx[key];
+            return m_lo_pred.predecessor_seeded(x, p, q);
+        }
+    }
+
+    // finds the smallest element greater than OR equal to x
+    inline result successor(const item_t x) const {
+        if(unlikely(x <= m_min)) return result { true, 0 };
+        if(unlikely(x > m_max))  return result { false, 0 };
+
+        const uint64_t key = hi(x) - m_key_min;
+        const size_t _q = m_hi_idx[key+1] + 1;
+        const size_t q = _q - (_q >= m_num); // std::min(_q, m_num - 1);
+
+        if(unlikely(x == (*m_array)[q])) {
+            return result { true, q };
+        } else {
+            const size_t p = m_hi_idx[key] + 1;
+            return m_lo_pred.successor_seeded(x, p, q);
+        }
+    }
+};
+
+}}

--- a/lce-test/util/successor/rank.hpp
+++ b/lce-test/util/successor/rank.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "bit_vector.hpp"
+#include "bit_rank.hpp"
+#include "bit_select.hpp"
+
+#include "util.hpp"
+#include "result.hpp"
+
+namespace stash {
+namespace pred {
+
+// the "rank" data structure for successor queries
+template<typename array_t, typename item_t>
+class rank {
+private:
+    const array_t* m_array;
+    size_t      m_num;
+    item_t      m_min;
+    item_t      m_max;
+    bit_vector  m_bv;
+    bit_rank    m_rank;
+
+public:
+    inline rank(const array_t& array)
+        : m_array(&array),
+          m_num(array.size()),
+          m_min(array[0]),
+          m_max(array[m_num-1]) {
+
+        assert_sorted_ascending(array);
+
+        m_bv = bit_vector(m_max - m_min);
+        for(size_t i = 0; i < m_num; i++) {
+            m_bv[array[i] - m_min] = 1;
+        }
+
+        assert(m_bv[0] == 1);
+        assert(m_bv[m_num-1] == 1);
+
+        m_rank = bit_rank(m_bv);
+    }
+
+    // finds the greatest element less than OR equal to x
+    inline result predecessor(item_t x) const {
+        if(unlikely(x < m_min))  return result { false, 0 };
+        if(unlikely(x >= m_max)) return result { true, m_num-1 };
+
+        const size_t p = m_rank(x - m_min);
+        assert(p > 0);
+        return result { true, p - 1 };
+    }
+
+    // finds the smallest element greater than OR equal to x
+    inline result successor(item_t x) const {
+        if(unlikely(x <= m_min))  return result { true, 0 };
+        if(unlikely(x > m_max)) return result { false, 0 };
+
+        const size_t p = m_rank(x - m_min);
+        assert(p > 0);
+        return result { true, p - 1 + (x > (*m_array)[p - 1]) };
+    }
+};
+
+}}

--- a/lce-test/util/successor/result.hpp
+++ b/lce-test/util/successor/result.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace stash {
+namespace pred {
+
+struct result {
+    bool   exists;
+    size_t pos;
+
+    inline operator bool() const {
+        return exists;
+    }
+
+    inline operator size_t() const {
+        return pos;
+    }
+};
+
+}}


### PR DESCRIPTION
My `stash` library is not really meant to be for the ages, so I incorporated everything needed for the successor data structures into this repository. I also added brief comments to the classes and successor / predecessor queries.

Note that there is duplicate code now (bit vectors and rank on bit vectors).