### PR TITLE
Fix wrong LCE results in corner cases

### DIFF
--- a/lce-test/lce_semi_synchronizing_sets.hpp
+++ b/lce-test/lce_semi_synchronizing_sets.hpp
@@ -73,7 +73,7 @@ public:
     fill_synchronizing_set(0, (text_length_in_bytes_ - (2*kTau)), fp,
                            fingerprints, s_fingerprints);
     
-    ind_ = std::make_unique<stash::pred::index<std::vector<sss_type>, sss_type, 7>>(sync_set_);         
+    ind_ = std::make_unique<stash::pred::index<std::vector<sss_type>, sss_type, 7>>(sync_set_);
 
     lce_rmq_ = std::make_unique<Lce_rmq<sss_type, kTau>>(text_.data(),
                                                          text_length_in_bytes_,
@@ -90,8 +90,8 @@ public:
     }
 
     if constexpr (prefer_long) {
-      uint64_t const i_ = suc(i);
-      uint64_t const j_ = suc(j);
+      uint64_t const i_ = suc(i + 1);
+      uint64_t const j_ = suc(j + 1);
       uint64_t const dist_i = sync_set_[i_] - i;
       uint64_t const dist_j = sync_set_[j_] - j;
       
@@ -136,7 +136,7 @@ public:
       return l + sync_set_[i_] - i;
     } else {
       /* naive part */
-      uint64_t const sync_length = 3 * kTau - 1;
+      uint64_t const sync_length = 3 * kTau;
       uint64_t const max_length = (i < j) ?
         ((sync_length + j > text_length_in_bytes_) ?
          text_length_in_bytes_ - j  :
@@ -174,8 +174,8 @@ public:
         }
       }
       /* strSync part */
-      uint64_t const i_ = suc(i);
-      uint64_t const j_ = suc(j);
+      uint64_t const i_ = suc(i + 1);
+      uint64_t const j_ = suc(j + 1);
 
       uint64_t const l = lce_rmq_->lce(i_, j_);
 

--- a/lce-test/util/synchronizing_sets/lce-rmq.hpp
+++ b/lce-test/util/synchronizing_sets/lce-rmq.hpp
@@ -74,18 +74,20 @@ public:
       new_text.push_back(static_cast<int32_t>(rank_tuples[i].rank));
     }
     new_text.push_back(0);
-    sais_int(new_text.data(), new_sa.data(), new_text.size(), 2 * cur_rank + 1);
+    sais_int(new_text.data(), new_sa.data(), new_text.size(), cur_rank + 1);
 
     lcp = std::vector<uint64_t>(new_sa.size() - 1, 0);
-
     isa.resize(new_sa.size() - 1);
+
     for(uint64_t i = 1; i < new_sa.size() - 1; ++i) {
       isa[new_sa[i]] = i - 1;
       lcp[i] = lce_in_text(sync_set[new_sa[i]],
                            sync_set[new_sa[i + 1]]);
     }
+    isa[new_sa[new_sa.size() - 1]] = new_sa.size() - 2;
 
     //Build RMQ data structure
+
     rmq_ds1 = std::make_unique<RMQRMM64>((long int*)lcp.data(), lcp.size());
   }
     
@@ -123,7 +125,7 @@ private:
   std::unique_ptr<RMQRMM64> rmq_ds1;
 
   inline void radixsort(indexed_string* strings, size_t n) {
-    msd_CE0(strings, n);
+    bingmann_msd_CI3_sb(strings, n);
   }
 
 
@@ -136,7 +138,6 @@ private:
       }
       ++lce_naive;
     }
-    std::cout << std::endl;
     return lce_naive;
   }
 };

--- a/lce-test/util/synchronizing_sets/lce-rmq.hpp
+++ b/lce-test/util/synchronizing_sets/lce-rmq.hpp
@@ -102,7 +102,6 @@ public:
     if (max - min > 1024) {
       return lcp[rmq_ds1->queryRMQ(min, max)];
     }
-
     auto result = lcp[min];
     for (auto i = min + 1; i <= max; ++i) {
       result = std::min(result, lcp[i]);
@@ -124,7 +123,7 @@ private:
   std::unique_ptr<RMQRMM64> rmq_ds1;
 
   inline void radixsort(indexed_string* strings, size_t n) {
-    bingmann_msd_CI3_sb(strings, n);
+    msd_CE0(strings, n);
   }
 
 

--- a/lce-test/util/synchronizing_sets/string_sorting.hpp
+++ b/lce-test/util/synchronizing_sets/string_sorting.hpp
@@ -70,7 +70,7 @@ static void inline inssort(indexed_string* strings, size_t n,
 template <size_t IS_THRESHOLD = 32>
 void inline msd_CE0(indexed_string* strings, indexed_string* sorted, size_t n,
                     uint64_t depth) {
-  if (n <= 1 || depth > 3 * kTau) {
+  if (n <= 1) {
     return;
   }
 
@@ -104,6 +104,11 @@ void inline msd_CE0(indexed_string* strings, indexed_string* sorted, size_t n,
     }
   }
 
+}
+
+inline void msd_CE0(indexed_string* strings, size_t n) {
+  std::vector<indexed_string> buffer(n);
+  msd_CE0(strings, buffer.data(), n, 0);
 }
 
 struct RadixStep_CI2_sb


### PR DESCRIPTION
This pull request fixes the last two bugs in the LCE data structures using string synchronizing sets:

1.  RMQ returns 0 due to the last LCP value is not computed
2.  The successor data structure returns the element if it is contained, we need the successor