### PR TITLE
PGM Branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/kurpicz/sais-lite-lcp
 [submodule "extlib/libsais"]
 	path = extlib/libsais
-	url = git@github.com:IlyaGrebnov/libsais.git
+	url = https://github.com/IlyaGrebnov/libsais
 [submodule "extlib/ips4o"]
 	path = extlib/ips4o
 	url = https://github.com/ips4o/ips4o

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "extlib/parallel-hashmap"]
 	path = extlib/parallel-hashmap
 	url = https://github.com/greg7mdp/parallel-hashmap
+[submodule "extlib/PGM-index"]
+	path = extlib/PGM-index
+	url = https://github.com/gvinciguerra/PGM-index.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,14 @@ set(CMAKE_CXX_FLAGS_RELEASE
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG")
 
 # find OpenMP
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+option(ALLOW_PARALLEL "Allow use of parallel algorithms" ON)
+if (ALLOW_PARALLEL)
+  find_package(OpenMP)
+  if (OPENMP_FOUND)
+      set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -DALLOW_PARALLEL")
+      set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  endif()
 endif()
 
 # include ferrada's rmq implementation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2019 Alexander Herlez <alexander.herlez@tu-dortmund.de>
 # Copyright (C) 2019 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+# Copyright (C) 2022 Patrick Dinklage <patrick.dinklage@tu-dortmund.de>
 #
 # All rights reserved. Published under the BSD-2 license in the LICENSE file.
 ################################################################################
@@ -85,5 +86,12 @@ find_package(TBB REQUIRED)
 add_subdirectory(benchmark)
 #set(IPS4O_USE_OPENMP TRUE)
 #add_subdirectory(extlib/ips4o)
+
+# include PGM index
+add_library(pgm_index INTERFACE)
+target_include_directories(pgm_index INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extlib/PGM-index/include/>
+  $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extlib/PGM-index/include/>
+)
 
 ################################################################################

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -90,5 +90,12 @@ target_link_libraries(bench_sparse_ss PRIVATE tlx malloc_count -ldl libsais TBB:
 add_executable(genqueries genqueries.cpp)
 target_link_libraries(genqueries PRIVATE tlx)
 
+add_executable(bench_predecessor bench_predecessor.cpp)
+target_link_libraries(bench_predecessor PRIVATE pgm_index tlx malloc_count -ldl)
+
+target_include_directories(bench_predecessor PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lce-test/>
+  $<INSTALL_INTERFACE:${PROJECT_SOURCE_DIR}/lce-test/>
+)
 
 ################################################################################

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(bench_time SYSTEM PRIVATE
 )
 
 target_link_libraries(bench_time PRIVATE
-  ferrada_rmq tlx sais_lcp libsais ${SDSL} ${divsufsort} ${divsufsort64} pgm_index malloc_count -ldl -fopenmp PRIVATE TBB::tbb)
+  ferrada_rmq tlx sais_lcp libsais ${SDSL} ${divsufsort} ${divsufsort64} pgm_index malloc_count -ldl PRIVATE TBB::tbb)
 
 
 option(LCE_BUILD_SDSL

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -24,9 +24,16 @@ add_executable(bench_time
 
 target_compile_options(bench_time PRIVATE -Wall -Wextra -pedantic -O3) #-Winline -Werror
 
-find_package(SDSL REQUIRED)
-find_package(divsufsort REQUIRED)
-find_package(divsufsort64 REQUIRED)
+if (LCE_BUILD_SDSL)
+  find_package(SDSL REQUIRED)
+  find_package(divsufsort REQUIRED)
+  find_package(divsufsort64 REQUIRED)
+else()
+  set(SDSL_INCLUDE_DIRS "")
+  set(SDSL "")
+  set(divsufsort "")
+  set(divsufsort64 "")
+endif()
 
 target_include_directories(bench_time PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lce-test/>

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(bench_time SYSTEM PRIVATE
 )
 
 target_link_libraries(bench_time PRIVATE
-  ferrada_rmq tlx sais_lcp libsais ${SDSL} ${divsufsort} ${divsufsort64} malloc_count -ldl -fopenmp PRIVATE TBB::tbb)
+  ferrada_rmq tlx sais_lcp libsais ${SDSL} ${divsufsort} ${divsufsort64} pgm_index malloc_count -ldl -fopenmp PRIVATE TBB::tbb)
 
 
 option(LCE_BUILD_SDSL

--- a/benchmark/bench_predecessor.cpp
+++ b/benchmark/bench_predecessor.cpp
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * benchmark/bench_predecessor.cpp
+ *
+ * Copyright (C) 2022 Patrick Dinklage <patrick.dinklage@tu-dortmund.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include <cstdlib>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <tlx/cmdline_parser.hpp>
+
+#include <malloc_count.h>
+
+#include "util/successor/binsearch.hpp"
+#include "util/successor/binsearch_cache.hpp"
+#include "util/successor/index.hpp"
+#include "util/successor/pgm_index.hpp"
+#include "util/successor/rank.hpp"
+
+uint64_t time() {
+    using namespace std::chrono;
+    return uint64_t(duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+}
+
+template<typename O>
+std::vector<O> load_file_lines_as_vector(const std::string& filename) {
+    std::vector<O> v;
+    std::ifstream f(filename);
+
+    // 2^64 has 20 decimal digits, so a buffer of size 24 should be safe
+    for(std::array<char, 24> linebuf; f.getline(&linebuf[0], 24);) {
+        if(linebuf[0]) {
+            v.push_back(O(uint64_t(std::atoll(&linebuf[0]))));
+        }
+    }
+
+    return v;
+}
+
+using namespace stash;
+
+using value_t = uint64_t;
+using binsearch       = pred::binsearch<std::vector<value_t>, value_t>;
+using binsearch_cache = pred::binsearch_cache<std::vector<value_t>, value_t>;
+using rank            = pred::rank<std::vector<value_t>, value_t>;
+
+template<size_t k>
+using index = pred::index<std::vector<value_t>, value_t, k>;
+
+template<size_t epsilon>
+using pgm_index = pred::pgm_index<std::vector<value_t>, value_t, epsilon>;
+
+std::vector<value_t> generate_queries(size_t num, size_t universe, size_t seed = 147ULL) {
+    std::vector<value_t> queries;
+    queries.reserve(num);
+
+    // seed
+    std::default_random_engine gen(seed);
+    std::uniform_int_distribution<uint64_t> dist(0, universe);
+
+    // generate
+    for(size_t i = 0; i < num; i++) {
+        queries.push_back(value_t(dist(gen)));
+    }
+
+    return queries;
+}
+
+std::string test_types[] = { "predecessor", "successor" };
+
+struct test_result {
+    uint8_t  type;
+    uint64_t t_construct;
+    size_t   m_ds;
+    uint64_t t_queries;
+    uint64_t sum;
+};
+
+template<typename pred_t>
+test_result test_predecessor(
+    const std::vector<value_t>& array,
+    const std::vector<value_t>& queries) {
+
+    // construct
+    auto t0 = time();
+    auto m0 = malloc_count_current();
+    pred_t q(array);
+    uint64_t t_construct = time() - t0;
+    size_t   m_ds = malloc_count_current() - m0;
+
+    // do queries
+    const auto min = array[0];
+    uint64_t t_queries;
+    uint64_t sum = 0;
+    {
+        auto t0 = time();
+        for(value_t x : queries) {
+            auto r = q.predecessor(x);
+
+            if(x >= min) {
+                assert(r.exists);
+                assert(x >= array[r.pos]);
+                sum += array[r.pos];
+            } else {
+                assert(!r.exists);
+            }
+        }
+        t_queries = time() - t0;
+    }
+
+    return test_result { 0, t_construct, m_ds, t_queries, sum };
+}
+
+template<typename pred_t>
+test_result test_successor(
+    const std::vector<value_t>& array,
+    const std::vector<value_t>& queries) {
+
+    // construct
+    auto t0 = time();
+    auto m0 = malloc_count_current();
+    pred_t q(array);
+    uint64_t t_construct = time() - t0;
+    size_t   m_ds = malloc_count_current() - m0;
+
+    // do queries
+    const auto max = array[array.size()-1ULL];
+    uint64_t t_queries;
+    uint64_t sum = 0;
+    {
+        auto t0 = time();
+        for(value_t x : queries) {
+            auto r = q.successor(x);
+            if(x <= max) {
+                assert(r.exists);
+                assert(x <= array[r.pos]);
+                sum += array[r.pos];
+            } else {
+                assert(!r.exists);
+            }
+        }
+        t_queries = time() - t0;
+    }
+
+    return test_result { 1, t_construct, m_ds, t_queries, sum };
+}
+
+int main(int argc, char** argv) {
+    tlx::CmdlineParser cp;
+
+    std::string input_filename;
+    cp.add_param_string("file", input_filename, "The input file, containing a string representation of a number per line.");
+
+    size_t num_queries = 10'000'000ULL;
+    cp.add_bytes('q', "queries", num_queries, "The number of queries to perform.");
+
+    size_t universe = 0;
+    cp.add_bytes('u', "universe", universe, "The universe to draw query numbers from. Default is maximum value + 1.");
+
+    bool add_max = false;
+    cp.add_flag('m', "max", add_max, "Append the maximum possible value to the input sequence.");
+
+    bool no_pred = false;
+    cp.add_bool("no-pred", no_pred, "Don't do predecessor benchmark.");
+
+    bool no_succ = false;
+    cp.add_bool("no-succ", no_succ, "Don't do successor benchmark.");
+
+    if (!cp.process(argc, argv)) {
+        return -1;
+    }
+
+    // load input
+    std::cout << "# loading input ..." << std::endl;
+
+    auto array = load_file_lines_as_vector<value_t>(input_filename);
+    if(!universe) {
+        universe = (size_t)array[array.size() - 1] + 1;
+    }
+
+    if(add_max) {
+        array.push_back(value_t(UINT64_MAX));
+    }
+
+    // generate queries
+    std::cout << "# generating queries ..." << std::endl;
+    auto queries = generate_queries(num_queries, universe);
+
+    // lambda to print a test result
+    auto print_result = [&](const std::string& name, test_result&& r){
+        std::cout << "RESULT algo="<< name
+            << " queries=" << queries.size()
+            << " type=" << test_types[r.type]
+            << " universe=" << universe
+            << " keys=" << array.size()
+            << " t_construct=" << r.t_construct
+            << " t_queries=" << r.t_queries
+            << " m_ds=" << r.m_ds
+            << " sum=" << r.sum << std::endl;
+    };
+
+    // run tests
+    if(!no_pred) {
+    std::cout << "# predecessor ..." << std::endl;
+    print_result("bs", test_predecessor<binsearch>(array, queries));
+    print_result("bs*", test_predecessor<binsearch_cache>(array, queries));
+    print_result("rank", test_predecessor<rank>(array, queries));
+    print_result("pgm<4>", test_predecessor<pgm_index<4>>(array, queries));
+    print_result("pgm<8>", test_predecessor<pgm_index<8>>(array, queries));
+    print_result("pgm<12>", test_predecessor<pgm_index<12>>(array, queries));
+    print_result("pgm<16>", test_predecessor<pgm_index<16>>(array, queries));
+    print_result("pgm<20>", test_predecessor<pgm_index<20>>(array, queries));
+    print_result("pgm<24>", test_predecessor<pgm_index<24>>(array, queries));
+    print_result("pgm<32>", test_predecessor<pgm_index<32>>(array, queries));
+    print_result("idx<4>", test_predecessor<index<4>>(array, queries));
+    print_result("idx<5>", test_predecessor<index<5>>(array, queries));
+    print_result("idx<6>", test_predecessor<index<6>>(array, queries));
+    print_result("idx<7>", test_predecessor<index<7>>(array, queries));
+    print_result("idx<8>", test_predecessor<index<8>>(array, queries));
+    print_result("idx<9>", test_predecessor<index<9>>(array, queries));
+    print_result("idx<10>", test_predecessor<index<10>>(array, queries));
+    print_result("idx<11>", test_predecessor<index<11>>(array, queries));
+    print_result("idx<12>", test_predecessor<index<12>>(array, queries));
+    print_result("idx<13>", test_predecessor<index<13>>(array, queries));
+    print_result("idx<14>", test_predecessor<index<14>>(array, queries));
+    print_result("idx<15>", test_predecessor<index<15>>(array, queries));
+    print_result("idx<16>", test_predecessor<index<16>>(array, queries));
+    }
+
+    if(!no_succ) {
+    std::cout << "# successor ..." << std::endl;
+    print_result("bs", test_successor<binsearch>(array, queries));
+    print_result("bs*", test_successor<binsearch_cache>(array, queries));
+    print_result("rank", test_successor<rank>(array, queries));
+    print_result("pgm<4>", test_successor<pgm_index<4>>(array, queries));
+    print_result("pgm<8>", test_successor<pgm_index<8>>(array, queries));
+    print_result("pgm<12>", test_successor<pgm_index<12>>(array, queries));
+    print_result("pgm<16>", test_successor<pgm_index<16>>(array, queries));
+    print_result("pgm<20>", test_successor<pgm_index<20>>(array, queries));
+    print_result("pgm<24>", test_successor<pgm_index<24>>(array, queries));
+    print_result("pgm<32>", test_successor<pgm_index<32>>(array, queries));
+    print_result("idx<4>", test_successor<index<4>>(array, queries));
+    print_result("idx<5>", test_successor<index<5>>(array, queries));
+    print_result("idx<6>", test_successor<index<6>>(array, queries));
+    print_result("idx<7>", test_successor<index<7>>(array, queries));
+    print_result("idx<8>", test_successor<index<8>>(array, queries));
+    print_result("idx<9>", test_successor<index<9>>(array, queries));
+    print_result("idx<10>", test_successor<index<10>>(array, queries));
+    print_result("idx<11>", test_successor<index<11>>(array, queries));
+    print_result("idx<12>", test_successor<index<12>>(array, queries));
+    print_result("idx<13>", test_successor<index<13>>(array, queries));
+    print_result("idx<14>", test_successor<index<14>>(array, queries));
+    print_result("idx<15>", test_successor<index<15>>(array, queries));
+    print_result("idx<16>", test_successor<index<16>>(array, queries));
+    }
+}

--- a/benchmark/bench_predecessor.cpp
+++ b/benchmark/bench_predecessor.cpp
@@ -23,6 +23,10 @@
 #include "util/successor/pgm_index.hpp"
 #include "util/successor/rank.hpp"
 
+#ifdef ALLOW_PARALLEL
+#include "util/successor/index_par.hpp"
+#endif
+
 uint64_t time() {
     using namespace std::chrono;
     return uint64_t(duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
@@ -52,6 +56,11 @@ using rank            = pred::rank<std::vector<value_t>, value_t>;
 
 template<size_t k>
 using index = pred::index<std::vector<value_t>, value_t, k>;
+
+#ifdef ALLOW_PARALLEL
+template<size_t k>
+using index_par = pred::index_par<std::vector<value_t>, value_t, k>;
+#endif
 
 template<size_t epsilon>
 using pgm_index = pred::pgm_index<std::vector<value_t>, value_t, epsilon>;
@@ -175,9 +184,15 @@ int main(int argc, char** argv) {
     if (!cp.process(argc, argv)) {
         return -1;
     }
+    
+    #ifdef ALLOW_PARALLEL
+    std::cout << "# benchmarking PARALLEL construction" << std::endl;
+    #else
+    std::cout << "# benchmarking SEQUENTIAL construction" << std::endl;
+    #endif
 
     // load input
-    std::cout << "# loading input ..." << std::endl;
+    std::cout << "# loading input: " << input_filename << std::endl;
 
     auto array = load_file_lines_as_vector<value_t>(input_filename);
     if(!universe) {
@@ -208,16 +223,25 @@ int main(int argc, char** argv) {
     // run tests
     if(!no_pred) {
     std::cout << "# predecessor ..." << std::endl;
+    
+    #ifdef ALLOW_PARALLEL
+    print_result("idx<4>", test_predecessor<index_par<4>>(array, queries));
+    print_result("idx<5>", test_predecessor<index_par<5>>(array, queries));
+    print_result("idx<6>", test_predecessor<index_par<6>>(array, queries));
+    print_result("idx<7>", test_predecessor<index_par<7>>(array, queries));
+    print_result("idx<8>", test_predecessor<index_par<8>>(array, queries));
+    print_result("idx<9>", test_predecessor<index_par<9>>(array, queries));
+    print_result("idx<10>", test_predecessor<index_par<10>>(array, queries));
+    print_result("idx<11>", test_predecessor<index_par<11>>(array, queries));
+    print_result("idx<12>", test_predecessor<index_par<12>>(array, queries));
+    print_result("idx<13>", test_predecessor<index_par<13>>(array, queries));
+    print_result("idx<14>", test_predecessor<index_par<14>>(array, queries));
+    print_result("idx<15>", test_predecessor<index_par<15>>(array, queries));
+    print_result("idx<16>", test_predecessor<index_par<16>>(array, queries));
+    #else
     print_result("bs", test_predecessor<binsearch>(array, queries));
     print_result("bs*", test_predecessor<binsearch_cache>(array, queries));
     print_result("rank", test_predecessor<rank>(array, queries));
-    print_result("pgm<4>", test_predecessor<pgm_index<4>>(array, queries));
-    print_result("pgm<8>", test_predecessor<pgm_index<8>>(array, queries));
-    print_result("pgm<12>", test_predecessor<pgm_index<12>>(array, queries));
-    print_result("pgm<16>", test_predecessor<pgm_index<16>>(array, queries));
-    print_result("pgm<20>", test_predecessor<pgm_index<20>>(array, queries));
-    print_result("pgm<24>", test_predecessor<pgm_index<24>>(array, queries));
-    print_result("pgm<32>", test_predecessor<pgm_index<32>>(array, queries));
     print_result("idx<4>", test_predecessor<index<4>>(array, queries));
     print_result("idx<5>", test_predecessor<index<5>>(array, queries));
     print_result("idx<6>", test_predecessor<index<6>>(array, queries));
@@ -231,20 +255,38 @@ int main(int argc, char** argv) {
     print_result("idx<14>", test_predecessor<index<14>>(array, queries));
     print_result("idx<15>", test_predecessor<index<15>>(array, queries));
     print_result("idx<16>", test_predecessor<index<16>>(array, queries));
+    #endif
+    
+    print_result("pgm<4>", test_predecessor<pgm_index<4>>(array, queries));
+    print_result("pgm<8>", test_predecessor<pgm_index<8>>(array, queries));
+    print_result("pgm<12>", test_predecessor<pgm_index<12>>(array, queries));
+    print_result("pgm<16>", test_predecessor<pgm_index<16>>(array, queries));
+    print_result("pgm<20>", test_predecessor<pgm_index<20>>(array, queries));
+    print_result("pgm<24>", test_predecessor<pgm_index<24>>(array, queries));
+    print_result("pgm<32>", test_predecessor<pgm_index<32>>(array, queries));
     }
 
     if(!no_succ) {
     std::cout << "# successor ..." << std::endl;
+    
+    #ifdef ALLOW_PARALLEL
+    print_result("idx<4>", test_successor<index_par<4>>(array, queries));
+    print_result("idx<5>", test_successor<index_par<5>>(array, queries));
+    print_result("idx<6>", test_successor<index_par<6>>(array, queries));
+    print_result("idx<7>", test_successor<index_par<7>>(array, queries));
+    print_result("idx<8>", test_successor<index_par<8>>(array, queries));
+    print_result("idx<9>", test_successor<index_par<9>>(array, queries));
+    print_result("idx<10>", test_successor<index_par<10>>(array, queries));
+    print_result("idx<11>", test_successor<index_par<11>>(array, queries));
+    print_result("idx<12>", test_successor<index_par<12>>(array, queries));
+    print_result("idx<13>", test_successor<index_par<13>>(array, queries));
+    print_result("idx<14>", test_successor<index_par<14>>(array, queries));
+    print_result("idx<15>", test_successor<index_par<15>>(array, queries));
+    print_result("idx<16>", test_successor<index_par<16>>(array, queries));
+    #else
     print_result("bs", test_successor<binsearch>(array, queries));
     print_result("bs*", test_successor<binsearch_cache>(array, queries));
     print_result("rank", test_successor<rank>(array, queries));
-    print_result("pgm<4>", test_successor<pgm_index<4>>(array, queries));
-    print_result("pgm<8>", test_successor<pgm_index<8>>(array, queries));
-    print_result("pgm<12>", test_successor<pgm_index<12>>(array, queries));
-    print_result("pgm<16>", test_successor<pgm_index<16>>(array, queries));
-    print_result("pgm<20>", test_successor<pgm_index<20>>(array, queries));
-    print_result("pgm<24>", test_successor<pgm_index<24>>(array, queries));
-    print_result("pgm<32>", test_successor<pgm_index<32>>(array, queries));
     print_result("idx<4>", test_successor<index<4>>(array, queries));
     print_result("idx<5>", test_successor<index<5>>(array, queries));
     print_result("idx<6>", test_successor<index<6>>(array, queries));
@@ -258,5 +300,14 @@ int main(int argc, char** argv) {
     print_result("idx<14>", test_successor<index<14>>(array, queries));
     print_result("idx<15>", test_successor<index<15>>(array, queries));
     print_result("idx<16>", test_successor<index<16>>(array, queries));
+    #endif
+    
+    print_result("pgm<4>", test_successor<pgm_index<4>>(array, queries));
+    print_result("pgm<8>", test_successor<pgm_index<8>>(array, queries));
+    print_result("pgm<12>", test_successor<pgm_index<12>>(array, queries));
+    print_result("pgm<16>", test_successor<pgm_index<16>>(array, queries));
+    print_result("pgm<20>", test_successor<pgm_index<20>>(array, queries));
+    print_result("pgm<24>", test_successor<pgm_index<24>>(array, queries));
+    print_result("pgm<32>", test_successor<pgm_index<32>>(array, queries));
     }
 }

--- a/benchmark/bench_predecessor.cpp
+++ b/benchmark/bench_predecessor.cpp
@@ -256,7 +256,6 @@ int main(int argc, char** argv) {
     print_result("idx<15>", test_predecessor<index<15>>(array, queries));
     print_result("idx<16>", test_predecessor<index<16>>(array, queries));
     #endif
-    
     print_result("pgm<4>", test_predecessor<pgm_index<4>>(array, queries));
     print_result("pgm<8>", test_predecessor<pgm_index<8>>(array, queries));
     print_result("pgm<12>", test_predecessor<pgm_index<12>>(array, queries));
@@ -264,6 +263,12 @@ int main(int argc, char** argv) {
     print_result("pgm<20>", test_predecessor<pgm_index<20>>(array, queries));
     print_result("pgm<24>", test_predecessor<pgm_index<24>>(array, queries));
     print_result("pgm<32>", test_predecessor<pgm_index<32>>(array, queries));
+    print_result("pgm<48>", test_predecessor<pgm_index<48>>(array, queries));
+    print_result("pgm<64>", test_predecessor<pgm_index<64>>(array, queries));
+    print_result("pgm<80>", test_predecessor<pgm_index<80>>(array, queries));
+    print_result("pgm<96>", test_predecessor<pgm_index<96>>(array, queries));
+    print_result("pgm<112>", test_predecessor<pgm_index<112>>(array, queries));
+    print_result("pgm<128>", test_predecessor<pgm_index<128>>(array, queries));
     }
 
     if(!no_succ) {
@@ -309,5 +314,11 @@ int main(int argc, char** argv) {
     print_result("pgm<20>", test_successor<pgm_index<20>>(array, queries));
     print_result("pgm<24>", test_successor<pgm_index<24>>(array, queries));
     print_result("pgm<32>", test_successor<pgm_index<32>>(array, queries));
+    print_result("pgm<48>", test_successor<pgm_index<48>>(array, queries));
+    print_result("pgm<64>", test_successor<pgm_index<64>>(array, queries));
+    print_result("pgm<80>", test_successor<pgm_index<80>>(array, queries));
+    print_result("pgm<96>", test_successor<pgm_index<96>>(array, queries));
+    print_result("pgm<112>", test_successor<pgm_index<112>>(array, queries));
+    print_result("pgm<128>", test_successor<pgm_index<128>>(array, queries));
     }
 }

--- a/benchmark/bench_time.cpp
+++ b/benchmark/bench_time.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2019 Alexander Herlez <alexander.herlez@tu-dortmund.de>
  * Copyright (C) 2019 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2022 Patrick Dinklage <patrick.dinklage@tu-dortmund.de>
  *
  * All rights reserved. Published under the BSD-2 license in the LICENSE file.
  ******************************************************************************/
@@ -29,7 +30,10 @@
 #include "lce_prezza.hpp"
 #include "lce_prezza_mersenne.hpp"
 #include "lce_semi_synchronizing_sets.hpp"
+
+#ifdef ALLOW_PARALLEL
 #include "lce_semi_synchronizing_sets_par.hpp"
+#endif
 
 #include "lce_sdsl_cst.hpp"
 
@@ -161,7 +165,9 @@ public:
         construction_times.add(t.get_and_reset());
         lce_mem.add(malloc_count_current() - mem_before);
         construction_mem_peak.add(malloc_count_peak() - mem_before);
-      } else if (algorithm == "s2048_par") {
+      }
+#ifdef ALLOW_PARALLEL
+      else if (algorithm == "s2048_par") {
         size_t const mem_before = malloc_count_current();
         t.reset();
         if (prefer_long_queries) {
@@ -206,7 +212,9 @@ public:
         construction_times.add(t.get_and_reset());
         lce_mem.add(malloc_count_current() - mem_before);
         construction_mem_peak.add(malloc_count_peak() - mem_before);
-      } else if (algorithm == "sada") {
+      }
+#endif
+      else if (algorithm == "sada") {
         size_t const mem_before = malloc_count_current();
         t.reset();
         lce_structure = std::make_unique<LceSDSLsada>(file_path);

--- a/lce-test/util/successor/binsearch_cache.hpp
+++ b/lce-test/util/successor/binsearch_cache.hpp
@@ -9,7 +9,7 @@ namespace pred {
 // the "bs*" data structure for successor queries
 template<typename array_t, typename item_t, size_t m_cache_num = 512ULL / sizeof(item_t)>
 class binsearch_cache {
-private:
+protected:
     const array_t* m_array;
     size_t m_num;
     item_t m_min;

--- a/lce-test/util/successor/helpers/util.hpp
+++ b/lce-test/util/successor/helpers/util.hpp
@@ -19,6 +19,11 @@ void assert_sorted_ascending([[maybe_unused]] const array_t& a) {
     #endif
 }
 
+inline constexpr uint64_t idiv_ceil(const uint64_t a, const uint64_t b) {
+    const uint64_t q = a / b;
+    return (a % b == 0) ? q : q + 1;
+}
+
 inline constexpr uint64_t log2_ceil(uint64_t x) {
     return 64ULL - __builtin_clzll(x);
 }

--- a/lce-test/util/successor/index.hpp
+++ b/lce-test/util/successor/index.hpp
@@ -65,7 +65,7 @@ public:
         }
 
         assert(prev_key == m_key_max);
-        m_hi_idx[m_key_max - m_key_min] = m_num - 1;
+        m_hi_idx[m_key_max - m_key_min + 1] = m_num - 1;
 
         // build the predecessor data structure for low bits
         m_lo_pred = lo_pred_t(array);

--- a/lce-test/util/successor/index_par.hpp
+++ b/lce-test/util/successor/index_par.hpp
@@ -72,7 +72,7 @@ public:
                 prev_key = cur_key;
             }
         }
-        m_hi_idx[m_key_max - m_key_min] = m_num - 1;
+        m_hi_idx[m_key_max - m_key_min + 1] = m_num - 1;
 
         // build the predecessor data structure for low bits
         m_lo_pred = lo_pred_t(array);

--- a/lce-test/util/successor/pgm_index.hpp
+++ b/lce-test/util/successor/pgm_index.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "binsearch_cache.hpp"
+#include <pgm/pgm_index.hpp>
+
+namespace stash {
+namespace pred {
+
+// a wrapper around the PGM index for successor queries
+template<typename array_t, typename item_t, size_t m_epsilon, size_t m_cache_num = 512ULL / sizeof(item_t)>
+class pgm_index : public binsearch_cache<array_t, item_t, m_cache_num> {
+private:
+    using base_t = binsearch_cache<array_t, item_t, m_cache_num>;
+
+    using base_t::m_min;
+    using base_t::m_max;
+    using base_t::m_num;
+
+    pgm::PGMIndex<item_t, m_epsilon> m_pgm;
+
+public:
+    inline pgm_index() : base_t() {
+    }
+
+    pgm_index(pgm_index const&) = default;
+    pgm_index& operator=(pgm_index const&) = default;
+    pgm_index(pgm_index&&) = default;
+    pgm_index& operator=(pgm_index&&) = default;
+
+    inline pgm_index(const array_t& array) : base_t(array), m_pgm(array.data(), array.data() + array.size()) {
+    }
+
+    // finds the greatest element less than OR equal to x
+    inline result predecessor(const item_t x) const {
+      if(unlikely(x < m_min))  return result { false, 0 };
+      if(unlikely(x >= m_max)) return result { true, m_num-1 };
+
+      auto const range = m_pgm.search(x);
+      return base_t::predecessor_seeded(x, range.lo, range.hi);
+    }
+
+    // finds the smallest element greater than OR equal to x
+    inline result successor(const item_t x) const {
+      if(unlikely(x <= m_min)) return result { true, 0 };
+      if(unlikely(x > m_max))  return result { false, 0 };
+
+      auto const range = m_pgm.search(x);
+      return base_t::successor_seeded(x, range.lo, range.hi);
+    }
+};
+
+}}

--- a/lce-test/util/successor/pgm_index.hpp
+++ b/lce-test/util/successor/pgm_index.hpp
@@ -27,7 +27,7 @@ public:
     pgm_index(pgm_index&&) = default;
     pgm_index& operator=(pgm_index&&) = default;
 
-    inline pgm_index(const array_t& array) : base_t(array), m_pgm(array.data(), array.data() + array.size()) {
+    inline pgm_index(const array_t& array) : base_t(array), m_pgm(array.data(), array.data() + array.size() - 1) {
     }
 
     // finds the greatest element less than OR equal to x
@@ -35,7 +35,13 @@ public:
       if(unlikely(x < m_min))  return result { false, 0 };
       if(unlikely(x >= m_max)) return result { true, m_num-1 };
 
-      auto const range = m_pgm.search(x);
+      auto range = m_pgm.search(x);
+
+      // nb: the PGM index returns the interval that would contain x if it were contained
+      // the predecessor and successor may thus be the items just outside the interval!
+      if(range.lo) --range.lo;
+      if(range.hi+1) ++range.hi;
+
       return base_t::predecessor_seeded(x, range.lo, range.hi);
     }
 
@@ -44,7 +50,13 @@ public:
       if(unlikely(x <= m_min)) return result { true, 0 };
       if(unlikely(x > m_max))  return result { false, 0 };
 
-      auto const range = m_pgm.search(x);
+      auto range = m_pgm.search(x);
+
+      // nb: the PGM index returns the interval that would contain x if it were contained
+      // the predecessor and successor may thus be the items just outside the interval!
+      if(range.lo) --range.lo;
+      if(range.hi+1) ++range.hi;
+
       return base_t::successor_seeded(x, range.lo, range.hi);
     }
 };

--- a/lce-test/util/successor/rank.hpp
+++ b/lce-test/util/successor/rank.hpp
@@ -30,13 +30,13 @@ public:
 
         assert_sorted_ascending(array);
 
-        m_bv = bit_vector(m_max - m_min);
+        m_bv = bit_vector(m_max - m_min + 1);
         for(size_t i = 0; i < m_num; i++) {
             m_bv[array[i] - m_min] = 1;
         }
 
         assert(m_bv[0] == 1);
-        assert(m_bv[m_num-1] == 1);
+        assert(m_bv[m_max - m_min] == 1);
 
         m_rank = bit_rank(m_bv);
     }

--- a/lce-test/util/successor/rank.hpp
+++ b/lce-test/util/successor/rank.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "bit_vector.hpp"
-#include "bit_rank.hpp"
-#include "bit_select.hpp"
+#include "helpers/bit_vector.hpp"
+#include "helpers/bit_rank.hpp"
+#include "helpers/bit_select.hpp"
 
-#include "util.hpp"
+#include "helpers/util.hpp"
 #include "result.hpp"
 
 namespace stash {


### PR DESCRIPTION
Adds:

- `ALLOW_PARALLEL` flag to enable or disable parallel computations on build level.
- Fix bug in `index` and `index_par` (information on last bucket not correctly stored).
- Fix bug in `rank`, as well as wrong assertion.
- Include PGM index and wrapper for predecessor and successor queries.
- Benchmark for predecessor or successor data structures.