### PR TITLE
Fix Binary Name `bench_time`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Note that this options invalidates all other times and memory measurements for t
 
 Now, that we have built the code, we can use our benchmark tool to evaluate the data structures.
 To this end, change to ``build/benchmark``.
-To get an overview about all possible benchmark parameters, we can use ``benchmark_time -help``.
+To get an overview about all possible benchmark parameters, we can use ``./bench_time --help``.
 
 There are two different modes (``-m`` or ``--modes``) for our benchmarks:
 1. random, which asks random queries and


### PR DESCRIPTION
As the build produces a binary called `bench_time`, we rename a reference to `benchmark_time` to the correct `bench_time`.

```bash
aryehh@debian:~/Development/lce-test/build/benchmark$ ls -l
total 2720
-rwxr-xr-x 1 aryehh aryehh  463232 May  7 14:17 bench_predecessor
-rwxr-xr-x 1 aryehh aryehh  980912 May  7 14:17 bench_sparse_ss
-rwxr-xr-x 1 aryehh aryehh 1163928 May  7 14:18 bench_time
drwxr-xr-x 6 aryehh aryehh    4096 May  7 14:20 CMakeFiles
-rw-r--r-- 1 aryehh aryehh    1264 May  7 14:16 cmake_install.cmake
-rwxr-xr-x 1 aryehh aryehh  143904 May  7 14:17 genqueries
-rw-r--r-- 1 aryehh aryehh   11422 May  7 14:16 Makefile
```

We also change `-help` to `--help` per the binary's CLI parser.

Before:
```bash
aryehh@debian:~/Development/lce-test/build/benchmark$ ./bench_time -help | head -n 3
Error: unknown option "-h" at position 1 in option sequence "-help".

Usage: ./bench_time [options] <file>
```

After:
```bash
aryehh@debian:~/Development/lce-test/build/benchmark$ ./bench_time --help | head -n 3
Usage: ./bench_time [options] <file>

This programs measures construction time and LCE query time for several LCE 
```

---

Addresses https://github.com/herlez/lce-test/issues/19